### PR TITLE
Add linkOrText macro to render plain text when href is empty

### DIFF
--- a/defectTemplates/DAST/dast_template.ftl
+++ b/defectTemplates/DAST/dast_template.ftl
@@ -1,3 +1,10 @@
+<#macro linkOrText href text>
+    <#if href!="">
+        <a href="${href}">${text}</a>
+    <#else>
+        ${text}
+    </#if>
+</#macro>
 <#macro tableRowIfParamIsNotEmptyString name param>
     <#if param!="">
         <tr>
@@ -57,20 +64,20 @@
 
         <#list issues?sort_by("severity") as issue>
             <tr>
-                <td><a href="${issue.link}">${issue.id}</a></td>
+                <td><@linkOrText href=issue.link text=issue.id/></td>
                 <td>${issue.title}</td>
                 <td>${issue.severity}</td>
-                <td><a href="${issue.externalLink}">${issue.foundBy}</a></td>
+                <td><@linkOrText href=issue.externalLink text=issue.foundBy/></td>
             </tr>
         </#list>
     </table>
 </#if>
 <#if issues?size == 1>
     <#list issues as issue>
-        <p>ID: <a href="${issue.link}">${issue.id}</a></p>
+        <p>ID: <@linkOrText href=issue.link text=issue.id/></p>
         <p>Location: ${issue.title}</p>
         <p>Severity: ${issue.severity}</p>
-        <p>Tool: <a href="${issue.externalLink}">${issue.foundBy}</a></p>
+        <p>Tool: <@linkOrText href=issue.externalLink text=issue.foundBy/></p>
     </#list>
 </#if>
 
@@ -82,7 +89,7 @@
     </tr>
     <#list issues?sort_by("severity") as issue>
         <tr>
-            <td><a href="${issue.link}">${issue.id}</a></td>
+            <td><@linkOrText href=issue.link text=issue.id/></td>
             <td>${issue.description}</td>
         </tr>
     </#list>

--- a/defectTemplates/DAST/dast_template_ru.ftl
+++ b/defectTemplates/DAST/dast_template_ru.ftl
@@ -1,3 +1,10 @@
+<#macro linkOrText href text>
+    <#if href!="">
+        <a href="${href}">${text}</a>
+    <#else>
+        ${text}
+    </#if>
+</#macro>
 <#macro tableRowIfParamIsNotEmptyString name param>
     <#if param!="">
         <tr>
@@ -57,20 +64,20 @@
 
         <#list issues?sort_by("severity") as issue>
             <tr>
-                <td><a href="${issue.link}">${issue.id}</a></td>
+                <td><@linkOrText href=issue.link text=issue.id/></td>
                 <td>${issue.title}</td>
                 <td>${issue.severity}</td>
-                <td><a href="${issue.externalLink}">${issue.foundBy}</a></td>
+                <td><@linkOrText href=issue.externalLink text=issue.foundBy/></td>
             </tr>
         </#list>
     </table>
 </#if>
 <#if issues?size == 1>
     <#list issues as issue>
-        <p>ID: <a href="${issue.link}">${issue.id}</a></p>
+        <p>ID: <@linkOrText href=issue.link text=issue.id/></p>
         <p>Расположение: ${issue.title}</p>
         <p>Серьёзность: ${issue.severity}</p>
-        <p>Инструмент: <a href="${issue.externalLink}">${issue.foundBy}</a></p>
+        <p>Инструмент: <@linkOrText href=issue.externalLink text=issue.foundBy/></p>
     </#list>
 </#if>
 
@@ -82,7 +89,7 @@
     </tr>
     <#list issues?sort_by("severity") as issue>
         <tr>
-            <td><a href="${issue.link}">${issue.id}</a></td>
+            <td><@linkOrText href=issue.link text=issue.id/></td>
             <td>${issue.description}</td>
         </tr>
     </#list>

--- a/defectTemplates/SAST/sast_template.ftl
+++ b/defectTemplates/SAST/sast_template.ftl
@@ -1,3 +1,10 @@
+<#macro linkOrText href text>
+    <#if href!="">
+        <a href="${href}">${text}</a>
+    <#else>
+        ${text}
+    </#if>
+</#macro>
 <#macro tableRowIfParamIsNotEmptyString name param>
     <#if param!="">
         <tr>
@@ -58,12 +65,12 @@
 
         <#list issues?sort_by("severity") as issue>
             <tr>
-                <td><a href="${issue.link}">${issue.id}</a></td>
+                <td><@linkOrText href=issue.link text=issue.id/></td>
                 <#if issue.path?size gt 0>
                     <td>${issue.path[0].fileName}:${issue.path[0].line}</td>
                 </#if>
                 <td>${issue.severity}</td>
-                <td><a href="${issue.externalLink}">${issue.foundBy}</a></td>
+                <td><@linkOrText href=issue.externalLink text=issue.foundBy/></td>
                 <td>${issue.category}</td>
             </tr>
         </#list>
@@ -71,12 +78,12 @@
 </#if>
 <#if issues?size == 1>
     <#list issues as issue>
-        <p>ID: <a href="${issue.link}">${issue.id}</a></p>
+        <p>ID: <@linkOrText href=issue.link text=issue.id/></p>
         <#if issue.path?size gt 0>
             <p>File: ${issue.path[0].fileName}:${issue.path[0].line}</p>
         </#if>
         <p>Severity: ${issue.severity}</p>
-        <p>Tool: <a href="${issue.externalLink}">${issue.foundBy}</a></p>
+        <p>Tool: <@linkOrText href=issue.externalLink text=issue.foundBy/></p>
         <p>Category: ${issue.category}</p>
     </#list>
 </#if>
@@ -89,7 +96,7 @@
     </tr>
     <#list issues?sort_by("severity") as issue>
         <tr>
-            <td><a href="${issue.link}">${issue.id}</a></td>
+            <td><@linkOrText href=issue.link text=issue.id/></td>
             <td><p><b>Path</b></p>
                 <ul>
                     <#list issue.path as item>

--- a/defectTemplates/SAST/sast_template_ru.ftl
+++ b/defectTemplates/SAST/sast_template_ru.ftl
@@ -1,3 +1,10 @@
+<#macro linkOrText href text>
+    <#if href!="">
+        <a href="${href}">${text}</a>
+    <#else>
+        ${text}
+    </#if>
+</#macro>
 <#macro tableRowIfParamIsNotEmptyString name param>
     <#if param!="">
         <tr>
@@ -58,12 +65,12 @@
 
         <#list issues?sort_by("severity") as issue>
             <tr>
-                <td><a href="${issue.link}">${issue.id}</a></td>
+                <td><@linkOrText href=issue.link text=issue.id/></td>
                 <#if issue.path?size gt 0>
                     <td>${issue.path[0].fileName}:${issue.path[0].line}</td>
                 </#if>
                 <td>${issue.severity}</td>
-                <td><a href="${issue.externalLink}">${issue.foundBy}</a></td>
+                <td><@linkOrText href=issue.externalLink text=issue.foundBy/></td>
                 <td>${issue.category}</td>
             </tr>
         </#list>
@@ -71,12 +78,12 @@
 </#if>
 <#if issues?size == 1>
     <#list issues as issue>
-        <p>ID: <a href="${issue.link}">${issue.id}</a></p>
+        <p>ID: <@linkOrText href=issue.link text=issue.id/></p>
         <#if issue.path?size gt 0>
             <p>Файл: ${issue.path[0].fileName}:${issue.path[0].line}</p>
         </#if>
         <p>Серьёзность: ${issue.severity}</p>
-        <p>Инструмент: <a href="${issue.externalLink}">${issue.foundBy}</a></p>
+        <p>Инструмент: <@linkOrText href=issue.externalLink text=issue.foundBy/></p>
         <p>Категория: ${issue.category}</p>
     </#list>
 </#if>
@@ -89,7 +96,7 @@
     </tr>
     <#list issues?sort_by("severity") as issue>
         <tr>
-            <td><a href="${issue.link}">${issue.id}</a></td>
+            <td><@linkOrText href=issue.link text=issue.id/></td>
             <td><p><b>Трасса</b></p>
                 <ul>
                     <#list issue.path as item>

--- a/defectTemplates/SCA_L/sca_l_template.ftl
+++ b/defectTemplates/SCA_L/sca_l_template.ftl
@@ -1,3 +1,10 @@
+<#macro linkOrText href text>
+    <#if href!="">
+        <a href="${href}">${text}</a>
+    <#else>
+        ${text}
+    </#if>
+</#macro>
 <#macro tableRowIfParamIsNotEmptyString name param>
     <#if param!="">
         <tr>
@@ -59,10 +66,10 @@
 
         <#list issues?sort_by("severity") as issue>
             <tr>
-                <td><a href="${issue.link}">${issue.id}</a></td>
+                <td><@linkOrText href=issue.link text=issue.id/></td>
                 <td>${issue.title}</td>
                 <td>${issue.severity}</td>
-                <td><a href="${issue.externalLink}">${issue.foundBy}</a></td>
+                <td><@linkOrText href=issue.externalLink text=issue.foundBy/></td>
                 <td>${issue.category}</td>
                 <td>${issue.threatGroup}</td>
             </tr>
@@ -71,10 +78,10 @@
 </#if>
 <#if issues?size == 1>
     <#list issues as issue>
-        <p>ID: <a href="${issue.link}">${issue.id}</a></p>
+        <p>ID: <@linkOrText href=issue.link text=issue.id/></p>
         <p>Component: ${issue.title}</p>
         <p>Severity: ${issue.severity}</p>
-        <p>Tool: <a href="${issue.externalLink}">${issue.foundBy}</a></p>
+        <p>Tool: <@linkOrText href=issue.externalLink text=issue.foundBy/></p>
         <p>Category: ${issue.category}</p>
         <p>Threat group: ${issue.threatGroup}</p>
     </#list>
@@ -88,7 +95,7 @@
     </tr>
     <#list issues?sort_by("severity") as issue>
         <tr>
-            <td><a href="${issue.link}">${issue.id}</a></td>
+            <td><@linkOrText href=issue.link text=issue.id/></td>
             <td>${issue.description}</td>
         </tr>
     </#list>

--- a/defectTemplates/SCA_L/sca_l_template_ru.ftl
+++ b/defectTemplates/SCA_L/sca_l_template_ru.ftl
@@ -1,3 +1,10 @@
+<#macro linkOrText href text>
+    <#if href!="">
+        <a href="${href}">${text}</a>
+    <#else>
+        ${text}
+    </#if>
+</#macro>
 <#macro tableRowIfParamIsNotEmptyString name param>
     <#if param!="">
         <tr>
@@ -59,10 +66,10 @@
 
         <#list issues?sort_by("severity") as issue>
             <tr>
-                <td><a href="${issue.link}">${issue.id}</a></td>
+                <td><@linkOrText href=issue.link text=issue.id/></td>
                 <td>${issue.title}</td>
                 <td>${issue.severity}</td>
-                <td><a href="${issue.externalLink}">${issue.foundBy}</a></td>
+                <td><@linkOrText href=issue.externalLink text=issue.foundBy/></td>
                 <td>${issue.category}</td>
                 <td>${issue.threatGroup}</td>
             </tr>
@@ -71,10 +78,10 @@
 </#if>
 <#if issues?size == 1>
     <#list issues as issue>
-        <p>ID: <a href="${issue.link}">${issue.id}</a></p>
+        <p>ID: <@linkOrText href=issue.link text=issue.id/></p>
         <p>Компонент: ${issue.title}</p>
         <p>Серьёзность: ${issue.severity}</p>
-        <p>Инструмент: <a href="${issue.externalLink}">${issue.foundBy}</a></p>
+        <p>Инструмент: <@linkOrText href=issue.externalLink text=issue.foundBy/></p>
         <p>Категория: ${issue.category}</p>
         <p>Группа угроз: ${issue.threatGroup}</p>
     </#list>
@@ -88,7 +95,7 @@
     </tr>
     <#list issues?sort_by("severity") as issue>
         <tr>
-            <td><a href="${issue.link}">${issue.id}</a></td>
+            <td><@linkOrText href=issue.link text=issue.id/></td>
             <td>${issue.description}</td>
         </tr>
     </#list>

--- a/defectTemplates/SCA_S/sca_s_template.ftl
+++ b/defectTemplates/SCA_S/sca_s_template.ftl
@@ -1,3 +1,10 @@
+<#macro linkOrText href text>
+    <#if href!="">
+        <a href="${href}">${text}</a>
+    <#else>
+        ${text}
+    </#if>
+</#macro>
 <#macro tableRowIfParamIsNotEmptyString name param>
     <#if param!="">
         <tr>
@@ -59,11 +66,11 @@
 
         <#list issues?sort_by("severity") as issue>
             <tr>
-                <td><a href="${issue.link}">${issue.id}</a></td>
+                <td><@linkOrText href=issue.link text=issue.id/></td>
                 <td>${issue.title}</td>
                 <td>${issue.severity}</td>
-                <td><a href="${issue.externalLink}">${issue.foundBy}</a></td>
-                <td><a href="${issue.cve.link}">${issue.cve.id}</a></td>
+                <td><@linkOrText href=issue.externalLink text=issue.foundBy/></td>
+                <td><@linkOrText href=issue.cve.link text=issue.cve.id/></td>
                 <td><#if issue.fixVersion!="">${issue.fixVersion}<#else>No info</#if></td>
             </tr>
         </#list>
@@ -71,11 +78,11 @@
 </#if>
 <#if issues?size == 1>
     <#list issues?sort_by("severity") as issue>
-        <p>ID: <a href="${issue.link}">${issue.id}</a></p>
+        <p>ID: <@linkOrText href=issue.link text=issue.id/></p>
         <p>Component: ${issue.title}</p>
         <p>Severity: ${issue.severity}</p>
-        <p>Tool: <a href="${issue.externalLink}">${issue.foundBy}</a></p>
-        <p>Vulnerability: <a href="${issue.cve.link}">${issue.cve.id}</a></p>
+        <p>Tool: <@linkOrText href=issue.externalLink text=issue.foundBy/></p>
+        <p>Vulnerability: <@linkOrText href=issue.cve.link text=issue.cve.id/></p>
         <#if issue.fixVersion!=""><p>Fix version: ${issue.fixVersion}</p></#if>
     </#list>
 </#if>
@@ -88,7 +95,7 @@
     </tr>
     <#list issues?sort_by("severity") as issue>
         <tr>
-            <td><a href="${issue.link}">${issue.id}</a></td>
+            <td><@linkOrText href=issue.link text=issue.id/></td>
             <td>${issue.description}</td>
         </tr>
     </#list>

--- a/defectTemplates/SCA_S/sca_s_template_ru.ftl
+++ b/defectTemplates/SCA_S/sca_s_template_ru.ftl
@@ -1,3 +1,10 @@
+<#macro linkOrText href text>
+    <#if href!="">
+        <a href="${href}">${text}</a>
+    <#else>
+        ${text}
+    </#if>
+</#macro>
 <#macro tableRowIfParamIsNotEmptyString name param>
     <#if param!="">
         <tr>
@@ -59,11 +66,11 @@
 
         <#list issues?sort_by("severity") as issue>
             <tr>
-                <td><a href="${issue.link}">${issue.id}</a></td>
+                <td><@linkOrText href=issue.link text=issue.id/></td>
                 <td>${issue.title}</td>
                 <td>${issue.severity}</td>
-                <td><a href="${issue.externalLink}">${issue.foundBy}</a></td>
-                <td><a href="${issue.cve.link}">${issue.cve.id}</a></td>
+                <td><@linkOrText href=issue.externalLink text=issue.foundBy/></td>
+                <td><@linkOrText href=issue.cve.link text=issue.cve.id/></td>
                 <td><#if issue.fixVersion!="">${issue.fixVersion}<#else>Нет информации</#if></td>
             </tr>
         </#list>
@@ -71,11 +78,11 @@
 </#if>
 <#if issues?size == 1>
     <#list issues?sort_by("severity") as issue>
-        <p>ID: <a href="${issue.link}">${issue.id}</a></p>
+        <p>ID: <@linkOrText href=issue.link text=issue.id/></p>
         <p>Компонент: ${issue.title}</p>
         <p>Серьёзность: ${issue.severity}</p>
-        <p>Инструмент: <a href="${issue.externalLink}">${issue.foundBy}</a></p>
-        <p>Уязвимость: <a href="${issue.cve.link}">${issue.cve.id}</a></p>
+        <p>Инструмент: <@linkOrText href=issue.externalLink text=issue.foundBy/></p>
+        <p>Уязвимость: <@linkOrText href=issue.cve.link text=issue.cve.id/></p>
         <#if issue.fixVersion!=""><p>Версия исправления: ${issue.fixVersion}</p></#if>
     </#list>
 </#if>
@@ -88,7 +95,7 @@
     </tr>
     <#list issues?sort_by("severity") as issue>
         <tr>
-            <td><a href="${issue.link}">${issue.id}</a></td>
+            <td><@linkOrText href=issue.link text=issue.id/></td>
             <td>${issue.description}</td>
         </tr>
     </#list>


### PR DESCRIPTION
Replace all raw <a> tags with linkOrText macro across all defect templates (SAST, DAST, SCA_L, SCA_S) in both EN and RU locales. When href variable is empty, the text is rendered without a link instead of producing a broken <a href="">.